### PR TITLE
Enhance LDAP VM setup and add MultiNetworkPolicy on localnet example

### DIFF
--- a/ldap/base/kustomization.yaml
+++ b/ldap/base/kustomization.yaml
@@ -33,6 +33,7 @@ secretGenerator:
 
 resources:
   - namespace.yaml
+  - multinetworkpolicy.yaml
 
 patches:
 

--- a/ldap/base/multinetworkpolicy.yaml
+++ b/ldap/base/multinetworkpolicy.yaml
@@ -1,0 +1,47 @@
+---
+# https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/networking#virt-connecting-vm-to-secondary-udn
+# selectors are not supported for secondary localnet networks. ipBlock must be used.
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: default/vlan-1924
+  name: demo-ldap-ingress
+  namespace: demo-ldap
+spec:
+  podSelector: {}
+
+  policyTypes:
+    - Ingress
+
+  ingress:
+    # allow from all to dhcpclient
+    - from:
+      ports:
+        - port: 67
+          protocol: UDP
+        - port: 68
+          protocol: UDP
+
+    # allow from wifi and lab network to ldap service
+    - from:
+        - ipBlock:
+            cidr: 192.168.3.0/24
+            except: []
+        - ipBlock:
+            cidr: 192.168.4.0/24
+            except: []
+      ports:
+        - port: 389
+          protocol: TCP
+        - port: 636
+          protocol: TCP
+
+    # allow from wifi network to ssh service
+    - from:
+        - ipBlock:
+            cidr: 192.168.3.0/24
+            except: []
+      ports:
+        - port: 22
+          protocol: TCP

--- a/ldap/base/scripts/userData
+++ b/ldap/base/scripts/userData
@@ -22,9 +22,10 @@ packages:
 mounts:
   - [ /dev/disk/by-id/virtio-ldap-ldif, /opt, iso9660, 'defaults' ]
 
-# https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 runcmd:
-  - [dnf, install, -y, https://rpmfind.net/linux/epel/9/Everything/x86_64/Packages/o/openldap-servers-2.6.6-3.el9.x86_64.rpm]
+  - [dnf, install, -y, https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm]
+  - [rpm, --import, /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-9]
+  - [dnf, install, -y, openldap-servers]
   - [systemctl, daemon-reload]
   - [systemctl, enable, slapd.service]
   - [systemctl, start, slapd.service]

--- a/ldap/readme.md
+++ b/ldap/readme.md
@@ -1,5 +1,123 @@
-# OpenLDAP Server in OpenShift Virtualization Linux VM 
+# OpenLDAP Server in OpenShift Virtualization Linux VM
 
+* Deploy and start the VM
 ```bash
 oc apply -k base
+virctl start -n demo-ldap ldap
+```
+
+## Firewalling with MultiNetworkPolicy
+
+This namespace has a [MultiNetworkPolicy](multinetworkpolicy.yaml) attached to it which permits only selective access to services on the LDAP server.
+
+MultiNetworkPolicy must be enabled on the OpenShift cluster first and may then be used for secondary network attachments. Localnet VLAN 1924 in this case. Because we are using localnet topology we can not use pod selectors and most discriminate based on IP address. [Other secondary network topologies can](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/multiple_networks/secondary-networks#compatibility-with-multi-network-policy_configuring-additional-network-ovnk) use selectors as long as they also include a subnet field.
+
+```yaml
+---
+# https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/networking#virt-connecting-vm-to-secondary-udn
+# selectors are not supported for secondary localnet networks. ipBlock must be used.
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: default/vlan-1924
+  name: demo-ldap-ingress
+  namespace: demo-ldap
+spec:
+  podSelector: {}
+
+  policyTypes:
+    - Ingress
+
+  ingress:
+    # allow from all to dhcpclient
+    - from:
+      ports:
+        - port: 67
+          protocol: UDP
+        - port: 68
+          protocol: UDP
+
+    # allow from wifi and lab network to ldap service
+    - from:
+        - ipBlock:
+            cidr: 192.168.3.0/24
+            except: []
+        - ipBlock:
+            cidr: 192.168.4.0/24
+            except: []
+      ports:
+        - port: 389
+          protocol: TCP
+        - port: 636
+          protocol: TCP
+
+    # allow from wifi network to ssh service
+    - from:
+        - ipBlock:
+            cidr: 192.168.3.0/24
+            except: []
+      ports:
+        - port: 22
+          protocol: TCP
+```
+
+
+### Policy Summary
+
+The `demo-ldap-ingress` MultiNetworkPolicy allows:
+
+1. **DHCP Client Access**: All networks can access DHCP client ports (67/UDP, 68/UDP) which enables DHCP to work on the VM
+2. **LDAP Service Access**: Only the WiFi (192.168.3.0/24) and Lab (192.168.4.0/24) networks can access LDAP ports (389/TCP, 636/TCP)
+3. **SSH Access**: Only WiFi network (192.168.3.0/24) can access SSH port (22/TCP)
+
+The policy is applied to the `default/vlan-1924` localnet network and affects all pods in the `demo-ldap` namespace using this secondary network.
+
+### Policy Diagram
+
+This diagram illustrates the 'demo-ldap-ingress' MultiNetworkPolicy applied to the 'ldap' virtual machine in the 'demo-ldap' namespace.
+
+```mermaid
+graph LR
+    subgraph "demo-ldap Namespace"
+        subgraph VM["LDAP Virtual Machine"]
+
+            DHCP[DHCP Client<br/>Ports: 67/UDP, 68/UDP]
+            LDAP[LDAP Service<br/>Ports: 389/TCP, 636/TCP]
+            SSH[SSH Service<br/>Port: 22/TCP]
+        end
+    end
+
+    subgraph "External Networks"
+        WIFI[💻 WiFi Network<br/>192.168.3.0/24]
+        LAB[🔬Lab Network<br/>192.168.4.0/24]
+        ALL[👬 All Networks]
+    end
+
+    %% DHCP access from all networks
+    ALL -->|UDP 67,68| DHCP
+
+    %% LDAP access from WiFi and Lab networks
+    WIFI -->|TCP 389,636| LDAP
+    LAB -->|TCP 389,636| LDAP
+
+    %% SSH access only from WiFi network
+    WIFI -->|TCP 22| SSH
+
+    %% Policy details
+    subgraph "MultiNetworkPolicy"
+        POLICY[👮 Policy applied to:<br/>default/vlan-1924]
+        POLICY -.-> VM
+    end
+
+    %% Styling
+    classDef vm fill:#e1f5fe,stroke:#01579b,stroke-width:2px
+    classDef service fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
+    classDef network fill:#e8f5e8,stroke:#1b5e20,stroke-width:2px
+    classDef policy fill:#fff3e0,stroke:#e65100,stroke-width:2px
+
+    class VM vm
+    class DHCP,LDAP,SSH service
+    class WIFI,LAB,ALL network
+    class POLICY policy
 ```


### PR DESCRIPTION
- Expanded the README to include detailed instructions for deploying the OpenLDAP server and configuring firewall rules using MultiNetworkPolicy.
- Introduced a new `multinetworkpolicy.yaml` file to define ingress rules for the LDAP service, allowing selective access based on network IP ranges.
- Updated `kustomization.yaml` to include the new MultiNetworkPolicy resource.
- Modified user data script to adjust user password settings and installation commands for OpenLDAP, ensuring proper configuration during VM setup.